### PR TITLE
Remove redundant quotes in FFmpegCommandBuilder default case

### DIFF
--- a/src/main/java/com/annimon/effybot/commands/ffmpeg/FFmpegCommandBuilder.java
+++ b/src/main/java/com/annimon/effybot/commands/ffmpeg/FFmpegCommandBuilder.java
@@ -92,10 +92,10 @@ public class FFmpegCommandBuilder implements Visitor<MediaSession> {
             case AudioEffect.NOISE_REDUCTION_12 -> "afftdn=nr=12";
             case AudioEffect.PULSATOR -> "apulsator=mode=sine:hz=0.5";
             case AudioEffect.VIBRATO -> "vibrato=f=4";
-            default /* AudioEffect.ROBOT */ -> "afftfilt=\"" +
+            default /* AudioEffect.ROBOT */ -> "afftfilt=" +
                     "real='hypot(re,im)*sin(0)'" +
                     ":imag='hypot(re,im)*cos(0)'" +
-                    ":win_size=512:overlap=0.75\"";
+                    ":win_size=512:overlap=0.75";
         });
     }
 


### PR DESCRIPTION
<img width="1226" height="214" alt="screenshot_20250903_054237" src="https://github.com/user-attachments/assets/90206d9e-7adb-48ee-bcd4-9c05b7e3f05a" />
